### PR TITLE
Windows Compat

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,20 @@
+install:
+  - set PATH=C:\Ruby22\bin;%PATH%
+  - bundle install
+
+build: off
+
+before_test:
+  - ruby -v
+  - gem -v
+  - bundle -v
+
+test_script:
+  - bundle exec rake
+
+environment:
+  matrix:
+    - RUBY_VERSION: 23
+    - RUBY_VERSION: 22
+    - RUBY_VERSION: 21
+    - RUBY_VERSION: 200

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,6 @@
+# Operating system (build VM template)
+os: Visual Studio 2015
+
 install:
   - set PATH=C:\Ruby22\bin;%PATH%
   - bundle install

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,23 +1,24 @@
-# Operating system (build VM template)
+---
 os: Visual Studio 2015
-
-install:
-  - set PATH=C:\Ruby22\bin;%PATH%
-  - bundle install
-
+version: "{build}"
 build: off
-
-before_test:
-  - ruby -v
-  - gem -v
-  - bundle -v
-
+clone_depth: 10
+install:
+  - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
+  - ruby --version
+  - gem --version
+  - gem install bundler --quiet --no-ri --no-rdoc
+  - bundler --version
+  - bundle install
 test_script:
-  - bundle exec rake
+  - bundle exec rake test
 
 environment:
   matrix:
-    - RUBY_VERSION: 23
-    - RUBY_VERSION: 22
-    - RUBY_VERSION: 21
-    - RUBY_VERSION: 200
+    - ruby_version: "193"
+    - ruby_version: "200"
+    - ruby_version: "200-x64"
+    - ruby_version: "21"
+    - ruby_version: "21-x64"
+    - ruby_version: "22"
+    - ruby_version: "22-x64"

--- a/lib/sassc/engine.rb
+++ b/lib/sassc/engine.rb
@@ -120,7 +120,7 @@ module SassC
 
     def load_paths
       paths = @options[:load_paths]
-      paths.join(":") if paths
+      paths.join(File::PATH_SEPARATOR) if paths
     end
   end
 end

--- a/lib/sassc/native.rb
+++ b/lib/sassc/native.rb
@@ -6,7 +6,12 @@ module SassC
 
     spec = Gem.loaded_specs["sassc"]
     gem_root = spec.gem_dir
-    ffi_lib "#{gem_root}/ext/libsass/lib/libsass.so"
+    if RUBY_PLATFORM =~ /mswin|mingw/
+      libsass_path = "#{gem_root}/ext/libsass/win/bin/libsass.dll"
+    else
+      libsass_path = "#{gem_root}/ext/libsass/lib/libsass.so"
+    end
+    ffi_lib libsass_path
 
     require_relative "native/sass_value"
 

--- a/lib/tasks/libsass.rb
+++ b/lib/tasks/libsass.rb
@@ -19,7 +19,7 @@ namespace :libsass do
   file "lib/libsass.so" => "Makefile" do
     make_program = ENV['MAKE']
     make_program ||= case RUBY_PLATFORM
-                     when /mswin/
+                     when /mswin|mingw/
                        'nmake'
                      when /(bsd|solaris)/
                        'gmake'

--- a/lib/tasks/libsass.rb
+++ b/lib/tasks/libsass.rb
@@ -20,12 +20,12 @@ namespace :libsass do
     make_program = ENV['MAKE']
     make_program ||= case RUBY_PLATFORM
                      when /mswin|mingw/
-                       'nmake'
+                       'msbuild /m:4 /p:Configuration=Release win/libsass.sln'
                      when /(bsd|solaris)/
-                       'gmake'
+                       'gmake lib/libsass.so'
                      else
-                       'make'
+                       'make lib/libsass.so'
                      end
-    sh "#{make_program} lib/libsass.so"
+    sh "#{make_program}"
   end
 end


### PR DESCRIPTION
- Path separators are platform dependent. We should use a cross platform API when building them.
